### PR TITLE
Add devise method for delete book authorization

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,6 @@ gem "geocoder"
 gem "gmaps4rails"
 gem 'owlcarousel-rails'
 
-
 source 'https://rails-assets.org' do
   gem "rails-assets-underscore"
 end

--- a/app/controllers/physical_books_controller.rb
+++ b/app/controllers/physical_books_controller.rb
@@ -1,6 +1,14 @@
 class PhysicalBooksController < ApplicationController
   before_action :set_book, only: [:show, :destroy]
   skip_before_action :authenticate_user!, only: [:index, :show]
+  before_filter :require_permission, only: :destroy
+
+  def require_permission
+    if current_user != PhysicalBook.find(params[:id]).user
+      redirect_to root_path
+      #Or do something else here
+    end
+  end
 
 
    def index

--- a/app/views/physical_books/index.html.erb
+++ b/app/views/physical_books/index.html.erb
@@ -1,7 +1,3 @@
-<%= content_for(:title) do %>
-  Bookaround | <%= @physical_books.count %> results
-<% end %>
-
 <% form_tag physical_books_path, method: :get do %>
 <p>
 <% text_field_tag :query, params[:query] %>

--- a/app/views/physical_books/show.html.erb
+++ b/app/views/physical_books/show.html.erb
@@ -11,10 +11,13 @@
     <h2><%= @book.title %></h2>
     <p><%= @book.author %></p>
     <p><%= @book.description %></p>
-    <%= link_to "Update Book", physical_book_path(@book), {class: "btn btn-primary"} %>
 
-    <%= link_to "Delete Book", physical_book_path(@book), class: "btn btn-primary", method: :delete, data: {confirm: "Are you sure you want to delete this book?"} %>
-    <%= link_to "User", physical_book_user_path(@book), class: "btn btn-primary" %>
+    <% if current_user == PhysicalBook.find(params[:id]).user %>
+      <%= link_to "Update Book", physical_book_path(@book), {class: "btn btn-primary"} %>
+
+      <%= link_to "Delete Book", physical_book_path(@book), class: "btn btn-primary", method: :delete, data: {confirm: "Are you sure you want to delete this book?"} %>
+    <% end %>
+      <%= link_to "User", physical_book_user_path(@book), class: "btn btn-primary" %>
 
     </div>
   </div>


### PR DESCRIPTION
Users who try to delete a book they have not uploaded themselves will now be redirected to the home page without deleting. The buttons for uploading and updating are now only shown to the book uploader as well.