### PR TITLE
Switched position of pic and name

### DIFF
--- a/app/views/conversations/show.html.erb
+++ b/app/views/conversations/show.html.erb
@@ -1,8 +1,8 @@
 
 <div class="container">
   <div class="panel panel-default messages msg-background">
-    <%= @other[0].first_name %>
     <%= image_tag @other[0].profile_pic_url, class: "avatar-sm" %>
+    <%= @other[0].first_name %>
     </div>
 
 


### PR DESCRIPTION
In conversation show, the "chatting with" now shows the profile picture first and then the name.